### PR TITLE
Patch libyaml for CVE-2013-6393

### DIFF
--- a/libyaml/0002-libyaml-string-overflow.diff
+++ b/libyaml/0002-libyaml-string-overflow.diff
@@ -1,0 +1,28 @@
+Description: CVE-2013-6393: yaml_parser_scan_tag_uri: fix int overflow leading to buffer overflow
+ This is a proposed patch from Florian Weimer <fweimer@redhat.com> for
+ the string overflow issue. It has been ack'd by upstream.
+Origin: https://bugzilla.redhat.com/show_bug.cgi?id=1033990
+Bug-RedHat: https://bugzilla.redhat.com/show_bug.cgi?id=1033990
+Bug-Debian: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=737076
+Last-Update: 2014-01-29
+---
+# HG changeset patch
+# User Florian Weimer <fweimer@redhat.com>
+# Date 1389273500 -3600
+#      Thu Jan 09 14:18:20 2014 +0100
+# Node ID a54d7af707f25dc298a7be60fd152001d2b3035b
+# Parent  3e6507fa0c26d20c09f8f468f2bd04aa2fd1b5b5
+yaml_parser_scan_tag_uri: fix int overflow leading to buffer overflow
+
+diff --git a/src/scanner.c b/src/scanner.c
+--- a/src/scanner.c
++++ b/src/scanner.c
+@@ -2574,7 +2574,7 @@
+ 
+     /* Resize the string to include the head. */
+ 
+-    while (string.end - string.start <= (int)length) {
++    while ((size_t)(string.end - string.start) <= length) {
+         if (!yaml_string_extend(&string.start, &string.pointer, &string.end)) {
+             parser->error = YAML_MEMORY_ERROR;
+             goto error;

--- a/libyaml/0003-libyaml-node-id-hardening.diff
+++ b/libyaml/0003-libyaml-node-id-hardening.diff
@@ -1,0 +1,35 @@
+Description: CVE-2013-6393: yaml_stack_extend: guard against integer overflow
+ This is a hardening patch also from Florian Weimer
+ <fweimer@redhat.com>.  It is not required to fix this CVE however it
+ improves the robustness of the code against future issues by avoiding
+ large node ID's in a central place.
+Origin: https://bugzilla.redhat.com/show_bug.cgi?id=1033990
+Bug-RedHat: https://bugzilla.redhat.com/show_bug.cgi?id=1033990
+Bug-Debian: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=737076
+Last-Update: 2014-01-29
+---
+# HG changeset patch
+# User Florian Weimer <fweimer@redhat.com>
+# Date 1389274355 -3600
+#      Thu Jan 09 14:32:35 2014 +0100
+# Node ID 034d7a91581ac930e5958683f1a06f41e96d24a2
+# Parent  a54d7af707f25dc298a7be60fd152001d2b3035b
+yaml_stack_extend: guard against integer overflow
+
+diff --git a/src/api.c b/src/api.c
+--- a/src/api.c
++++ b/src/api.c
+@@ -117,7 +117,12 @@
+ YAML_DECLARE(int)
+ yaml_stack_extend(void **start, void **top, void **end)
+ {
+-    void *new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
++    void *new_start;
++
++    if ((char *)*end - (char *)*start >= INT_MAX / 2)
++	return 0;
++
++    new_start = yaml_realloc(*start, ((char *)*end - (char *)*start)*2);
+ 
+     if (!new_start) return 0;
+ 

--- a/libyaml/0004-libyaml-indent-column-overflow-v2.diff
+++ b/libyaml/0004-libyaml-indent-column-overflow-v2.diff
@@ -1,0 +1,176 @@
+Description: CVE-2013-6393: yaml_parser-{un,}roll-indent: fix int overflow in column argument
+ This expands upon the original indent column overflow patch from
+ comment #12.
+ .
+ The default parser indention is represented as an indention of -1.
+ The original patch only modified the type of the column parameter to
+ the roll/unroll functions, changing it from int to size_t to guard
+ against integer overflow.  However, there are code paths that call
+ yaml_parser_unroll_indent with a column of -1 in order to reset the
+ parser back to the initial indention.  Since the column is now of
+ type size_t and thus unsigned, passing a column value of -1 caused
+ the column to underflow in this case.
+ .
+ This new patch modifies the roll/unroll functions to handle the -1
+ indent as a special case.  In addition, it adds a new function,
+ yaml_parser_reset_indent.  It is nearly an exact copy of
+ yaml_parser_unroll_indent, except it does not take a column
+ parameter.  Instead it unrolls to a literal -1 indention, which does
+ not suffer from the underflow.
+ .
+ Code paths that previously called yaml_parser_unroll_indent with a
+ column of -1 are updated to call the new yaml_parser_reset_indent
+ function instead.
+ .
+ With this patch instead of the original:
+ .
+ - `make check` still passes
+ .
+ - The reproducer script completes successfully with exit code 0
+ .
+ - The issue raised by John Haxby has been corrected and exits with SUCCESS
+Origin: https://bugzilla.redhat.com/show_bug.cgi?id=1033990
+Bug-RedHat: https://bugzilla.redhat.com/show_bug.cgi?id=1033990
+Bug-Debian: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=737076
+Last-Update: 2014-01-29
+---
+# HG changeset patch
+# User John Eckersberg <jeckersb@redhat.com>
+# Date 1390870108 18000
+#      Mon Jan 27 19:48:28 2014 -0500
+# Node ID 7179aa474f31e73834adda26b77bfc25bfe5143d
+# Parent  3e6507fa0c26d20c09f8f468f2bd04aa2fd1b5b5
+yaml_parser-{un,}roll-indent: fix int overflow in column argument
+
+diff -r 3e6507fa0c26 -r 7179aa474f31 src/scanner.c
+--- a/src/scanner.c	Mon Dec 24 03:51:32 2012 +0000
++++ b/src/scanner.c	Mon Jan 27 19:48:28 2014 -0500
+@@ -615,11 +615,14 @@
+  */
+ 
+ static int
+-yaml_parser_roll_indent(yaml_parser_t *parser, int column,
++yaml_parser_roll_indent(yaml_parser_t *parser, size_t column,
+         int number, yaml_token_type_t type, yaml_mark_t mark);
+ 
+ static int
+-yaml_parser_unroll_indent(yaml_parser_t *parser, int column);
++yaml_parser_unroll_indent(yaml_parser_t *parser, size_t column);
++
++static int
++yaml_parser_reset_indent(yaml_parser_t *parser);
+ 
+ /*
+  * Token fetchers.
+@@ -1206,7 +1209,7 @@
+  */
+ 
+ static int
+-yaml_parser_roll_indent(yaml_parser_t *parser, int column,
++yaml_parser_roll_indent(yaml_parser_t *parser, size_t column,
+         int number, yaml_token_type_t type, yaml_mark_t mark)
+ {
+     yaml_token_t token;
+@@ -1216,7 +1219,7 @@
+     if (parser->flow_level)
+         return 1;
+ 
+-    if (parser->indent < column)
++    if (parser->indent == -1 || parser->indent < column)
+     {
+         /*
+          * Push the current indentation level to the stack and set the new
+@@ -1254,7 +1257,7 @@
+ 
+ 
+ static int
+-yaml_parser_unroll_indent(yaml_parser_t *parser, int column)
++yaml_parser_unroll_indent(yaml_parser_t *parser, size_t column)
+ {
+     yaml_token_t token;
+ 
+@@ -1263,6 +1266,15 @@
+     if (parser->flow_level)
+         return 1;
+ 
++    /*
++     * column is unsigned and parser->indent is signed, so if
++     * parser->indent is less than zero the conditional in the while
++     * loop below is incorrect.  Guard against that.
++     */
++    
++    if (parser->indent < 0)
++        return 1;
++
+     /* Loop through the intendation levels in the stack. */
+ 
+     while (parser->indent > column)
+@@ -1283,6 +1295,41 @@
+ }
+ 
+ /*
++ * Pop indentation levels from the indents stack until the current
++ * level resets to -1.  For each intendation level, append the
++ * BLOCK-END token.
++ */
++
++static int
++yaml_parser_reset_indent(yaml_parser_t *parser)
++{
++    yaml_token_t token;
++
++    /* In the flow context, do nothing. */
++
++    if (parser->flow_level)
++        return 1;
++
++    /* Loop through the intendation levels in the stack. */
++
++    while (parser->indent > -1)
++    {
++        /* Create a token and append it to the queue. */
++
++        TOKEN_INIT(token, YAML_BLOCK_END_TOKEN, parser->mark, parser->mark);
++
++        if (!ENQUEUE(parser, parser->tokens, token))
++            return 0;
++
++        /* Pop the indentation level. */
++
++        parser->indent = POP(parser, parser->indents);
++    }
++
++    return 1;
++}
++
++/*
+  * Initialize the scanner and produce the STREAM-START token.
+  */
+ 
+@@ -1338,7 +1385,7 @@
+ 
+     /* Reset the indentation level. */
+ 
+-    if (!yaml_parser_unroll_indent(parser, -1))
++    if (!yaml_parser_reset_indent(parser))
+         return 0;
+ 
+     /* Reset simple keys. */
+@@ -1369,7 +1416,7 @@
+ 
+     /* Reset the indentation level. */
+ 
+-    if (!yaml_parser_unroll_indent(parser, -1))
++    if (!yaml_parser_reset_indent(parser))
+         return 0;
+ 
+     /* Reset simple keys. */
+@@ -1407,7 +1454,7 @@
+ 
+     /* Reset the indentation level. */
+ 
+-    if (!yaml_parser_unroll_indent(parser, -1))
++    if (!yaml_parser_reset_indent(parser))
+         return 0;
+ 
+     /* Reset simple keys. */


### PR DESCRIPTION
CVE-2013-6393 is a buffer overflow vulnerability that affects libyaml. A quote
from a synopsis of the vulnerability states that:

  LibYAML is prone to a remote heap-based buffer-overflow vulnerability because
  it fails to properly sanitize user-supplied input.

  Successful exploits allow remote attackers to execute arbitrary code in the
  context of the vulnerable application. Failed exploit attempts likely result
  in denial-of-service conditions.
